### PR TITLE
Add tests for new `data-reflex-dataset` and stack overlapping values

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -128,24 +128,29 @@ export const extractElementDataset = element => {
     const elementAttributes = extractDataAttributes(element)
 
     Object.keys(elementAttributes).forEach(key => {
-      if (attributes[key]) {
-        const pluralKey = `${key}s`
+      const value = elementAttributes[key]
+      const pluralKey = `${key}s`
 
+      if (attributes[key]) {
         if (Array.isArray(attributes[key])) {
-          attributes[key].push(elementAttributes[key])
+          attributes[key].push(value)
         } else {
           if (attributes[pluralKey]) {
             if (Array.isArray(attributes[pluralKey])) {
-              attributes[pluralKey].push(elementAttributes[key])
+              attributes[pluralKey].push(value)
             } else {
-              attributes[pluralKey] = [attributes[pluralKey], attributes[key], elementAttributes[key]].flat()
+              attributes[pluralKey] = [
+                attributes[pluralKey],
+                attributes[key],
+                value
+              ]
             }
           } else {
-            attributes[pluralKey] = [attributes[key], elementAttributes[key]]
+            attributes[pluralKey] = [attributes[key], value]
           }
         }
       } else {
-        attributes[key] = elementAttributes[key]
+        attributes[key] = value
       }
     })
   })

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -70,13 +70,16 @@ export const extractElementAttributes = element => {
   return attrs
 }
 
-// Extracts the dataset of an element and combines it with the data attributes from all specified tokens
+// Returns an array of elements for the provided tokens.
+// Tokens is an array of space separated string coming from the `data-reflex-dataset`
+// or `data-reflex-dataset-array` attribute.
 //
-export const extractElementDataset = element => {
+const getElementsFromTokens = (element, tokens) => {
+  if (!tokens || tokens.length === 0) return []
+
   let elements = [element]
+
   const xPath = elementToXPath(element)
-  const dataset = element.attributes[reflexes.app.schema.reflexDatasetAttribute]
-  const tokens = (dataset && dataset.value.split(' ')) || []
 
   tokens.forEach(token => {
     try {
@@ -122,40 +125,62 @@ export const extractElementDataset = element => {
     }
   })
 
-  let attributes = {}
+  return elements
+}
 
-  elements.forEach(element => {
+// Extracts the dataset of an element and combines it with the data attributes from all specified tokens
+//
+export const extractElementDataset = element => {
+  const dataset = element.attributes[reflexes.app.schema.reflexDatasetAttribute]
+  const arrayDataset =
+    element.attributes[reflexes.app.schema.reflexDatasetArrayAttribute]
+
+  const tokens = (dataset && dataset.value.split(' ')) || []
+  const arrayTokens = (arrayDataset && arrayDataset.value.split(' ')) || []
+
+  const datasetElements = getElementsFromTokens(element, tokens)
+  const datasetArrayElements = getElementsFromTokens(element, arrayTokens)
+
+  const datasetAttribtues = datasetElements.reduce((acc, ele) => {
+    return { ...extractDataAttributes(ele), ...acc }
+  }, {})
+
+  let datasetArrayAttribtues = {}
+
+  datasetArrayElements.forEach(element => {
     const elementAttributes = extractDataAttributes(element)
 
     Object.keys(elementAttributes).forEach(key => {
       const value = elementAttributes[key]
       const pluralKey = `${key}s`
 
-      if (attributes[key]) {
-        if (Array.isArray(attributes[key])) {
-          attributes[key].push(value)
-        } else {
-          if (attributes[pluralKey]) {
-            if (Array.isArray(attributes[pluralKey])) {
-              attributes[pluralKey].push(value)
-            } else {
-              attributes[pluralKey] = [
-                attributes[pluralKey],
-                attributes[key],
-                value
-              ]
-            }
-          } else {
-            attributes[pluralKey] = [attributes[key], value]
-          }
-        }
+      if (
+        datasetArrayAttribtues[pluralKey] &&
+        Array.isArray(datasetArrayAttribtues[pluralKey])
+      ) {
+        datasetArrayAttribtues[pluralKey].push(value)
       } else {
-        attributes[key] = value
+        datasetArrayAttribtues[pluralKey] = [value]
+      }
+
+      if (pluralKey.endsWith('ss')) {
+        if (
+          datasetArrayAttribtues[key] &&
+          Array.isArray(datasetArrayAttribtues[key])
+        ) {
+          datasetArrayAttribtues[key].push(value)
+        } else {
+          datasetArrayAttribtues[key] = [value]
+        }
       }
     })
   })
 
-  return attributes
+  return {
+    ...extractDataAttributes(element),
+    ...datasetAttribtues,
+    ...datasetArrayAttribtues
+  }
 }
 
 // Extracts all data attributes from a DOM element.

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -131,10 +131,18 @@ export const extractElementDataset = element => {
       if (attributes[key]) {
         const pluralKey = `${key}s`
 
-        if (attributes[pluralKey]) {
-          attributes[pluralKey].push(elementAttributes[key])
+        if (Array.isArray(attributes[key])) {
+          attributes[key].push(elementAttributes[key])
         } else {
-          attributes[pluralKey] = [attributes[key], elementAttributes[key]]
+          if (attributes[pluralKey]) {
+            if (Array.isArray(attributes[pluralKey])) {
+              attributes[pluralKey].push(elementAttributes[key])
+            } else {
+              attributes[pluralKey] = [attributes[pluralKey], attributes[key], elementAttributes[key]].flat()
+            }
+          } else {
+            attributes[pluralKey] = [attributes[key], elementAttributes[key]]
+          }
         }
       } else {
         attributes[key] = elementAttributes[key]

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -122,9 +122,27 @@ export const extractElementDataset = element => {
     }
   })
 
-  return elements.reduce((acc, ele) => {
-    return { ...extractDataAttributes(ele), ...acc }
-  }, {})
+  let attributes = {}
+
+  elements.forEach(element => {
+    const elementAttributes = extractDataAttributes(element)
+
+    Object.keys(elementAttributes).forEach(key => {
+      if (attributes[key]) {
+        const pluralKey = `${key}s`
+
+        if (attributes[pluralKey]) {
+          attributes[pluralKey].push(elementAttributes[key])
+        } else {
+          attributes[pluralKey] = [attributes[key], elementAttributes[key]]
+        }
+      } else {
+        attributes[key] = elementAttributes[key]
+      }
+    })
+  })
+
+  return attributes
 }
 
 // Extracts all data attributes from a DOM element.

--- a/javascript/schema.js
+++ b/javascript/schema.js
@@ -3,5 +3,6 @@ export const defaultSchema = {
   reflexPermanentAttribute: 'data-reflex-permanent',
   reflexRootAttribute: 'data-reflex-root',
   reflexDatasetAttribute: 'data-reflex-dataset',
+  reflexDatasetArrayAttribute: 'data-reflex-dataset-array',
   reflexSerializeFormAttribute: 'data-reflex-serialize-form'
 }

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -165,7 +165,6 @@ describe('extractElementDataset', () => {
     const actual = extractElementDataset(element)
     const expected = {
       'data-info': 'this is the inner one',
-      'data-infos': ['this is the inner one', 'this is the outer one'],
       'data-reflex-dataset': 'combined'
     }
     assert.deepStrictEqual(actual, expected)
@@ -400,7 +399,7 @@ describe('extractElementDataset', () => {
   it('should return dataset for first occurence and stack data values if they overlap', () => {
     const dom = new JSDOM(
       `
-      <div id="element" data-controller="posts" data-id="1" data-reflex-dataset=".post">
+      <div id="element" data-controller="posts" data-id="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
         <div class="post" data-post-id="1"></div>
         <div class="post" data-post-id="2"></div>
         <div class="post" data-post-id="3"></div>
@@ -413,18 +412,23 @@ describe('extractElementDataset', () => {
     const actual = extractElementDataset(element)
     const expected = {
       'data-controller': 'posts',
+      'data-controllers': ['posts'],
       'data-id': '1',
+      'data-ids': ['1'],
       'data-post-id': '1',
       'data-post-ids': ['1', '2', '3', '4'],
-      'data-reflex-dataset': '.post'
+      'data-reflex-dataset': '.post',
+      'data-reflex-datasets': ['.post'],
+      'data-reflex-dataset-array': '.post',
+      'data-reflex-dataset-arrays': ['.post']
     }
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('should return dataset if the plural of overlapped value is also used', () => {
+  it('should return dataset for data-reflex-dataset-array', () => {
     const dom = new JSDOM(
       `
-      <div id="element" data-controller="posts" data-post-ids="1" data-reflex-dataset=".post">
+      <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset-array=".post">
         <div class="post" data-post-id="2"></div>
         <div class="post" data-post-id="3"></div>
         <div class="post" data-post-id="4"></div>
@@ -436,14 +440,97 @@ describe('extractElementDataset', () => {
     const actual = extractElementDataset(element)
     const expected = {
       'data-controller': 'posts',
-      'data-post-id': '2',
+      'data-controllers': ['posts'],
+      'data-post-id': '1',
       'data-post-ids': ['1', '2', '3', '4'],
-      'data-reflex-dataset': '.post'
+      'data-reflex-dataset-array': '.post',
+      'data-reflex-dataset-arrays': ['.post']
     }
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('should return dataset if the plural of overlapped value is also used but plural comes after first singular value', () => {
+  it('should return dataset if the plural of overlapped value is also used in the first attribute with data-reflex-dataset-array', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="posts" data-post-ids="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
+        <div class="post" data-post-id="2"></div>
+        <div class="post" data-post-id="3"></div>
+        <div class="post" data-post-id="4"></div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'posts',
+      'data-controllers': ['posts'],
+      'data-post-id': '2',
+      'data-post-ids': ['1', '2', '3', '4'],
+      'data-post-idss': ['1'],
+      'data-reflex-dataset': '.post',
+      'data-reflex-datasets': ['.post'],
+      'data-reflex-dataset-array': '.post',
+      'data-reflex-dataset-arrays': ['.post']
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset if the plural of overlapped value is also used in the middle attribute with data-reflex-dataset-array', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
+        <div class="post" data-post-ids="2"></div>
+        <div class="post" data-post-ids="3"></div>
+        <div class="post" data-post-id="4"></div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'posts',
+      'data-controllers': ['posts'],
+      'data-post-id': '1',
+      'data-post-ids': ['1', '2', '3', '4'],
+      'data-post-idss': ['2', '3'],
+      'data-reflex-dataset': '.post',
+      'data-reflex-datasets': ['.post'],
+      'data-reflex-dataset-array': '.post',
+      'data-reflex-dataset-arrays': ['.post']
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset if the plural of overlapped value is also used in the last attribute with data-reflex-dataset-array', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
+        <div class="post" data-post-id="2"></div>
+        <div class="post" data-post-id="3"></div>
+        <div class="post" data-post-ids="4"></div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'posts',
+      'data-controllers': ['posts'],
+      'data-post-id': '1',
+      'data-post-ids': ['1', '2', '3', '4'],
+      'data-post-idss': ['4'],
+      'data-reflex-dataset': '.post',
+      'data-reflex-datasets': ['.post'],
+      'data-reflex-dataset-array': '.post',
+      'data-reflex-dataset-arrays': ['.post']
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset if both singular and plural exists but no data-reflex-dataset-array is passed', () => {
     const dom = new JSDOM(
       `
       <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post">
@@ -459,7 +546,7 @@ describe('extractElementDataset', () => {
     const expected = {
       'data-controller': 'posts',
       'data-post-id': '1',
-      'data-post-ids': ['1', '2', '3', '4'],
+      'data-post-ids': '4',
       'data-reflex-dataset': '.post'
     }
     assert.deepStrictEqual(actual, expected)

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -400,24 +400,79 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('should return dataset for first occurence if the same data attribute appears twice', () => {
+  it('should return dataset for first occurence and stack data values if they overlap', () => {
     const dom = new JSDOM(
       `
-      <div id="element" data-controller="foo" data-id="1" data-reflex-dataset=".post"></div>
-      <div class="post" data-one-id="1"></div>
-      <div class="post" data-one-id="2"></div>
-      <div class="post" data-one-id="3"></div>
-      <div class="post" data-one-id="4"></div>
+      <div id="element" data-controller="posts" data-id="1" data-reflex-dataset=".post">
+        <div class="post" data-post-id="1"></div>
+        <div class="post" data-post-id="2"></div>
+        <div class="post" data-post-id="3"></div>
+        <div class="post" data-post-id="4"></div>
+      </div>
       `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
+      'data-controller': 'posts',
       'data-id': '1',
-      'data-one-id': '1',
-      'data-one-ids': [
+      'data-post-id': '1',
+      'data-post-ids': [
+        '1',
+        '2',
+        '3',
+        '4'
+      ],
+      'data-reflex-dataset': '.post'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset if the plural of overlapped value is also used', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="posts" data-post-ids="1" data-reflex-dataset=".post">
+        <div class="post" data-post-id="2"></div>
+        <div class="post" data-post-id="3"></div>
+        <div class="post" data-post-id="4"></div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'posts',
+      'data-post-id': '2',
+      'data-post-ids': [
+        '1',
+        '2',
+        '3',
+        '4'
+      ],
+      'data-reflex-dataset': '.post'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset if the plural of overlapped value is also used but plural comes after first singular value', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post">
+        <div class="post" data-post-id="2"></div>
+        <div class="post" data-post-id="3"></div>
+        <div class="post" data-post-ids="4"></div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'posts',
+      'data-post-id': '1',
+      'data-post-ids': [
         '1',
         '2',
         '3',

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -165,10 +165,7 @@ describe('extractElementDataset', () => {
     const actual = extractElementDataset(element)
     const expected = {
       'data-info': 'this is the inner one',
-      'data-infos': [
-        'this is the inner one',
-        'this is the outer one'
-      ],
+      'data-infos': ['this is the inner one', 'this is the outer one'],
       'data-reflex-dataset': 'combined'
     }
     assert.deepStrictEqual(actual, expected)
@@ -418,12 +415,7 @@ describe('extractElementDataset', () => {
       'data-controller': 'posts',
       'data-id': '1',
       'data-post-id': '1',
-      'data-post-ids': [
-        '1',
-        '2',
-        '3',
-        '4'
-      ],
+      'data-post-ids': ['1', '2', '3', '4'],
       'data-reflex-dataset': '.post'
     }
     assert.deepStrictEqual(actual, expected)
@@ -445,12 +437,7 @@ describe('extractElementDataset', () => {
     const expected = {
       'data-controller': 'posts',
       'data-post-id': '2',
-      'data-post-ids': [
-        '1',
-        '2',
-        '3',
-        '4'
-      ],
+      'data-post-ids': ['1', '2', '3', '4'],
       'data-reflex-dataset': '.post'
     }
     assert.deepStrictEqual(actual, expected)
@@ -472,12 +459,7 @@ describe('extractElementDataset', () => {
     const expected = {
       'data-controller': 'posts',
       'data-post-id': '1',
-      'data-post-ids': [
-        '1',
-        '2',
-        '3',
-        '4'
-      ],
+      'data-post-ids': ['1', '2', '3', '4'],
       'data-reflex-dataset': '.post'
     }
     assert.deepStrictEqual(actual, expected)

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -152,11 +152,11 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('should returns dataset for element with overloaded data attributes', () => {
+  it('should return dataset for element with overloaded data attributes', () => {
     const dom = new JSDOM(
       `
-      <div data-info="this is the wrong one">
-        <a data-info="this is the right one" data-reflex-dataset="combined">Test</a>
+      <div data-info="this is the outer one">
+        <a data-info="this is the inner one" data-reflex-dataset="combined">Test</a>
       </div>
       `
     )
@@ -164,7 +164,11 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-info': 'this is the right one',
+      'data-info': 'this is the inner one',
+      'data-infos': [
+        'this is the inner one',
+        'this is the outer one'
+      ],
       'data-reflex-dataset': 'combined'
     }
     assert.deepStrictEqual(actual, expected)
@@ -413,6 +417,12 @@ describe('extractElementDataset', () => {
       'data-controller': 'foo',
       'data-id': '1',
       'data-one-id': '1',
+      'data-one-ids': [
+        '1',
+        '2',
+        '3',
+        '4'
+      ],
       'data-reflex-dataset': '.post'
     }
     assert.deepStrictEqual(actual, expected)

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -5,10 +5,13 @@ import reflexes from '../reflexes'
 import { defaultSchema } from '../schema'
 
 describe('extractElementDataset', () => {
-  reflexes.app = {}
-  reflexes.app.schema = defaultSchema
+  beforeEach(() => {
+    reflexes.app = {}
+    reflexes.app.schema = defaultSchema
+    reflexes.app.schema.reflexDatasetAttribute = 'data-reflex-dataset'
+  })
 
-  it('returns expected dataset for element without data attributes', () => {
+  it('should return dataset for element without data attributes', () => {
     const dom = new JSDOM('<a id="example">Test</a>')
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -17,7 +20,7 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset for element', () => {
+  it('should return dataset for element', () => {
     const dom = new JSDOM(
       '<a id="example" data-controller="foo" data-reflex="bar" data-info="12345">Test</a>'
     )
@@ -32,9 +35,13 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset for element without combining dataset from parent', () => {
+  it('should return dataset for element without combining dataset from parent', () => {
     const dom = new JSDOM(
-      '<div data-parent-id="should not be included"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345">Test</a></div>'
+      `
+      <div data-parent-id="should not be included">
+        <a id="example" data-controller="foo" data-reflex="bar" data-info="12345">Test</a>
+      </div>
+      `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -47,9 +54,13 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset for element but without providing the dataset attribute', () => {
+  it('should return dataset for element but without providing the dataset attribute', () => {
     const dom = new JSDOM(
-      '<div data-parent-id="should not be included"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345">Test</a></div>'
+      `
+      <div data-parent-id="should not be included">
+        <a id="example" data-controller="foo" data-reflex="bar" data-info="12345">Test</a>
+      </div>
+      `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -59,11 +70,30 @@ describe('extractElementDataset', () => {
       'data-info': '12345'
     }
     assert.deepStrictEqual(extractElementDataset(element), expected)
+
+    reflexes.app.schema.reflexDatasetAttribute = null
+    assert.deepStrictEqual(extractElementDataset(element), expected)
+
+    reflexes.app.schema.reflexDatasetAttribute = undefined
+    assert.deepStrictEqual(extractElementDataset(element), expected)
+
+    reflexes.app.schema.reflexDatasetAttribute = ''
+    assert.deepStrictEqual(extractElementDataset(element), expected)
+
+    reflexes.app.schema.reflexDatasetAttribute = 'blah'
+    assert.deepStrictEqual(extractElementDataset(element), expected)
+
+    reflexes.app.schema.reflexDatasetAttribute = {}
+    assert.deepStrictEqual(extractElementDataset(element), expected)
   })
 
-  it('returns expected dataset for element with data-reflex-dataset without value', () => {
+  it('should return dataset for element with data-reflex-dataset without value', () => {
     const dom = new JSDOM(
-      '<div data-parent-id="should not be included"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset>Test</a></div>'
+      `
+      <div data-parent-id="should not be included">
+        <a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset>Test</a>
+      </div>
+      `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -77,9 +107,13 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset for element with data-reflex-dataset and other value than "combined"', () => {
+  it('should return dataset for element with data-reflex-dataset and other value than "combined"', () => {
     const dom = new JSDOM(
-      '<div data-parent-id="should not be included"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset="whut">Test</a></div>'
+      `
+      <div data-parent-id="should not be included">
+        <a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset="whut">Test</a>
+      </div>
+      `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -93,9 +127,15 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset for element with data-reflex-dataset="combined"', () => {
+  it('should return dataset for element with data-reflex-dataset="combined"', () => {
     const dom = new JSDOM(
-      '<body data-body-id="body"><div data-grandparent-id="456"><div data-parent-id="123"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset="combined">Test</a></div></div></body>'
+      `
+      <body data-body-id="body">
+        <div data-grandparent-id="456">
+          <div data-parent-id="123"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset="combined">Test</a></div>
+        </div>
+      </body>
+      `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -112,9 +152,13 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset for element with overloaded data attributes', () => {
+  it('should returns dataset for element with overloaded data attributes', () => {
     const dom = new JSDOM(
-      '<div data-info="this is the wrong one"><a data-info="this is the right one" data-reflex-dataset="combined">Test</a></div>'
+      `
+      <div data-info="this is the wrong one">
+        <a data-info="this is the right one" data-reflex-dataset="combined">Test</a>
+      </div>
+      `
     )
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
@@ -126,9 +170,14 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('returns expected dataset with combined parent attributes only for elements with data-reflex-dataset', () => {
+  it('should return with combined parent attributes only for elements with data-reflex-dataset', () => {
     const dom = new JSDOM(
-      '<div data-parent-id="123"><button id="button1" data-reflex-dataset="combined">Something</button><button id="button2">Another thing</button></div>'
+      `
+      <div data-parent-id="123">
+        <button id="button1" data-reflex-dataset="combined">Something</button>
+        <button id="button2">Another thing</button>
+      </div>
+      `
     )
     global.document = dom.window.document
 
@@ -147,9 +196,16 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual_button2, expected_button2)
   })
 
-  it('returns expected dataset for element with different renamed data-reflex-dataset attribute', () => {
+  it('should return dataset for element with different renamed data-reflex-dataset attribute', () => {
     const dom = new JSDOM(
-      '<body data-body-id="body"><div data-grandparent-id="456"><div data-parent-id="123"><a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset-renamed="combined">Test</a></div></div></body>'
+      `<body data-body-id="body">
+        <div data-grandparent-id="456">
+          <div data-parent-id="123">
+            <a id="example" data-controller="foo" data-reflex="bar" data-info="12345" data-reflex-dataset-renamed="combined">Test</a>
+          </div>
+        </div>
+      </body>
+      `
     )
     global.document = dom.window.document
     reflexes.app.schema.reflexDatasetAttribute = 'data-reflex-dataset-renamed'
@@ -163,6 +219,312 @@ describe('extractElementDataset', () => {
       'data-parent-id': '123',
       'data-body-id': 'body',
       'data-reflex-dataset-renamed': 'combined'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for id', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-reflex-dataset="#timmy"></div>
+      <div id="timmy" data-age="12"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-age': '12',
+      'data-reflex-dataset': '#timmy'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for tag name', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-reflex-dataset="span"></div>
+      <span data-span-one="1"></span>
+      <span data-span-two="2"></span>
+      <div data-div="other"></div>
+      <div data-div="other"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-span-one': '1',
+      'data-span-two': '2',
+      'data-reflex-dataset': 'span'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for tag name with class', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-reflex-dataset="span.post"></div>
+      <span class="post" data-span-one="1"></span>
+      <span class="post" data-span-two="2"></span>
+      <span data-span="other"></span>
+      <span data-span="other"></span>
+      <div data-div="other"></div>
+      <div data-div="other"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-span-one': '1',
+      'data-span-two': '2',
+      'data-reflex-dataset': 'span.post'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for multiple elements with the same ids', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-reflex-dataset="#timmy"></div>
+      <div id="timmy" data-one="1"></div>
+      <div id="timmy" data-two="2"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-one': '1',
+      'data-two': '2',
+      'data-reflex-dataset': '#timmy'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for multiple different ids', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-reflex-dataset="#post1 #post2 #post3 #post4"></div>
+      <div id="post1" data-one-id="1"></div>
+      <div id="post2" data-two-id="2"></div>
+      <div id="post3" data-three-id="3"></div>
+      <div id="post4" data-four-id="4"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-one-id': '1',
+      'data-two-id': '2',
+      'data-three-id': '3',
+      'data-four-id': '4',
+      'data-reflex-dataset': '#post1 #post2 #post3 #post4'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for class', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-id="1" data-reflex-dataset=".sarah"></div>
+      <div class="sarah" data-job="clerk"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-id': '1',
+      'data-job': 'clerk',
+      'data-reflex-dataset': '.sarah'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for multiple elements with the same class', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-id="1" data-reflex-dataset=".post"></div>
+      <div class="post" data-one-id="1"></div>
+      <div class="post" data-two-id="2"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-id': '1',
+      'data-one-id': '1',
+      'data-two-id': '2',
+      'data-reflex-dataset': '.post'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for multiple different classes', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-id="1" data-reflex-dataset=".post1 .post2 .post3 .post4"></div>
+      <div class="post1" data-one-id="1"></div>
+      <div class="post2" data-two-id="2"></div>
+      <div class="post3" data-three-id="3"></div>
+      <div class="post4" data-four-id="4"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-id': '1',
+      'data-one-id': '1',
+      'data-two-id': '2',
+      'data-three-id': '3',
+      'data-four-id': '4',
+      'data-reflex-dataset': '.post1 .post2 .post3 .post4'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for first occurence if the same data attribute appears twice', () => {
+    const dom = new JSDOM(
+      `
+      <div id="element" data-controller="foo" data-id="1" data-reflex-dataset=".post"></div>
+      <div class="post" data-one-id="1"></div>
+      <div class="post" data-one-id="2"></div>
+      <div class="post" data-one-id="3"></div>
+      <div class="post" data-one-id="4"></div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-id': '1',
+      'data-one-id': '1',
+      'data-reflex-dataset': '.post'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for parent', () => {
+    const dom = new JSDOM(
+      `
+      <div data-dont-include="me">
+        <div data-controller="foo" data-parent-id="1">
+          <div data-dont-include="me"></div>
+          <div id="element" data-child-id="2" data-reflex-dataset="parent">
+            <div data-dont-include="me"></div>
+          </div>
+        </div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-parent-id': '1',
+      'data-child-id': '2',
+      'data-reflex-dataset': 'parent'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for ancestors', () => {
+    const dom = new JSDOM(
+      `
+      <div data-dont-include="me"></div>
+      <div data-controller="foo" data-grandparent-id="1">
+        <div data-dont-include="me"></div>
+        <div data-parent-id="2">
+          <div data-dont-include="me"></div>
+          <div id="element" data-child-id="3" data-reflex-dataset="ancestors">
+            <div data-dont-include="me"></div>
+          </div>
+        </div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-grandparent-id': '1',
+      'data-parent-id': '2',
+      'data-child-id': '3',
+      'data-reflex-dataset': 'ancestors'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for children', () => {
+    const dom = new JSDOM(
+      `
+      <div data-dont-include="me">
+        <div data-dont-include="me"></div>
+        <div id="element" data-controller="foo" data-id="1" data-reflex-dataset="children">
+          <div data-child-one-id="1">
+            <div data-dont-include="me"></div>
+          </div>
+          <div data-child-two-id="2">
+            <div data-dont-include="me"></div>
+          </div>
+        </div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-id': '1',
+      'data-child-one-id': '1',
+      'data-child-two-id': '2',
+      'data-reflex-dataset': 'children'
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should return dataset for siblings', () => {
+    const dom = new JSDOM(
+      `
+      <div data-dont-include="me">
+        <div id="element" data-controller="foo" data-id="1" data-reflex-dataset="siblings">
+          <div data-dont-include="me"></div>
+        </div>
+        <div data-sibling-one-id="1">
+          <div data-dont-include="me"></div>
+        </div>
+        <div data-sibling-two-id="2">
+          <div data-dont-include="me"></div>
+        </div>
+      </div>
+      `
+    )
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('#element')
+    const actual = extractElementDataset(element)
+    const expected = {
+      'data-controller': 'foo',
+      'data-id': '1',
+      'data-sibling-one-id': '1',
+      'data-sibling-two-id': '2',
+      'data-reflex-dataset': 'siblings'
     }
     assert.deepStrictEqual(actual, expected)
   })


### PR DESCRIPTION
This PR contains two things:

* Tests for the new features of the `data-reflex-dataset` attribute
  * `ancestors`
  * `parent`
  * `siblings`
  * `children`
  * `descendants`


* A new behaviour to stack and collect overlapping values

  Example:

  ```html
  <div data-reflex-dataset=".post">
    <div class="post" data-post-id="1"></div>
    <div class="post" data-post-id="2"></div>
    <div class="post" data-post-id="3"></div>
    <div class="post" data-post-id="4"></div>
  </div>
   ```

   Previously this returned this attributes object:
   ```js
  {
    'data-reflex-dataset': '.post',
    'data-post-id': '1'
  }
   ```

  However, if you now swap the attribute with `data-reflex-dataset-array`, like:

  ```html
  <div data-reflex-dataset-array=".post">
    <div class="post" data-post-id="1"></div>
    <div class="post" data-post-id="2"></div>
    <div class="post" data-post-id="3"></div>
    <div class="post" data-post-id="4"></div>
  </div>
   ```

   You will get this:
   ```js
  {
    'data-reflex-dataset-array': '.post',
    'data-reflex-dataset-arrays': ['.post'],
    'data-post-id': '1',
    'data-post-ids': [
      '1',
      '2',
      '3',
      '4'
    ]
  }
   ```

  Since the `data-post-id` always contains the first occurring value (like it was before) it's fully backwards compatible, because just the `data-post-ids` is added additionally.

  You can of course also mix-and-match the two attributes, but I would not recommend it.