### PR TITLE
move pluralize logic to `StimulusReflex::Element`

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -145,42 +145,31 @@ export const extractElementDataset = element => {
     return { ...extractDataAttributes(ele), ...acc }
   }, {})
 
-  let datasetArrayAttribtues = {}
+  const reflexElementAttribtues = extractDataAttributes(element)
+
+  const elementDataset = {
+    dataset: { ...reflexElementAttribtues, ...datasetAttribtues },
+    datasetArray: {}
+  }
 
   datasetArrayElements.forEach(element => {
     const elementAttributes = extractDataAttributes(element)
 
     Object.keys(elementAttributes).forEach(key => {
       const value = elementAttributes[key]
-      const pluralKey = `${key}s`
 
       if (
-        datasetArrayAttribtues[pluralKey] &&
-        Array.isArray(datasetArrayAttribtues[pluralKey])
+        elementDataset.datasetArray[key] &&
+        Array.isArray(elementDataset.datasetArray[key])
       ) {
-        datasetArrayAttribtues[pluralKey].push(value)
+        elementDataset.datasetArray[key].push(value)
       } else {
-        datasetArrayAttribtues[pluralKey] = [value]
-      }
-
-      if (pluralKey.endsWith('ss')) {
-        if (
-          datasetArrayAttribtues[key] &&
-          Array.isArray(datasetArrayAttribtues[key])
-        ) {
-          datasetArrayAttribtues[key].push(value)
-        } else {
-          datasetArrayAttribtues[key] = [value]
-        }
+        elementDataset.datasetArray[key] = [value]
       }
     })
   })
 
-  return {
-    ...extractDataAttributes(element),
-    ...datasetAttribtues,
-    ...datasetArrayAttribtues
-  }
+  return elementDataset
 }
 
 // Extracts all data attributes from a DOM element.

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -514,7 +514,7 @@ describe('extractElementDataset', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('should return dataset if the plural of overlapped value is also used in the first attribute with data-reflex-dataset-array', () => {
+  it('should return dataset if the plural of overlapped value is also used with data-reflex-dataset-array', () => {
     const dom = new JSDOM(
       `
       <div id="element" data-controller="posts" data-post-ids="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
@@ -539,70 +539,6 @@ describe('extractElementDataset', () => {
         'data-controller': ['posts'],
         'data-post-id': ['2', '3', '4'],
         'data-post-ids': ['1'],
-        'data-reflex-dataset': ['.post'],
-        'data-reflex-dataset-array': ['.post']
-      }
-    }
-    assert.deepStrictEqual(actual, expected)
-  })
-
-  it('should return dataset if the plural of overlapped value is also used in the middle attribute with data-reflex-dataset-array', () => {
-    const dom = new JSDOM(
-      `
-      <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
-        <div class="post" data-post-ids="2"></div>
-        <div class="post" data-post-ids="3"></div>
-        <div class="post" data-post-id="4"></div>
-      </div>
-      `
-    )
-    global.document = dom.window.document
-    const element = dom.window.document.querySelector('#element')
-    const actual = extractElementDataset(element)
-    const expected = {
-      dataset: {
-        'data-controller': 'posts',
-        'data-post-id': '1',
-        'data-post-ids': '2',
-        'data-reflex-dataset': '.post',
-        'data-reflex-dataset-array': '.post'
-      },
-      datasetArray: {
-        'data-controller': ['posts'],
-        'data-post-id': ['1', '4'],
-        'data-post-ids': ['2', '3'],
-        'data-reflex-dataset': ['.post'],
-        'data-reflex-dataset-array': ['.post']
-      }
-    }
-    assert.deepStrictEqual(actual, expected)
-  })
-
-  it('should return dataset if the plural of overlapped value is also used in the last attribute with data-reflex-dataset-array', () => {
-    const dom = new JSDOM(
-      `
-      <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post" data-reflex-dataset-array=".post">
-        <div class="post" data-post-id="2"></div>
-        <div class="post" data-post-id="3"></div>
-        <div class="post" data-post-ids="4"></div>
-      </div>
-      `
-    )
-    global.document = dom.window.document
-    const element = dom.window.document.querySelector('#element')
-    const actual = extractElementDataset(element)
-    const expected = {
-      dataset: {
-        'data-controller': 'posts',
-        'data-post-id': '1',
-        'data-post-ids': '4',
-        'data-reflex-dataset': '.post',
-        'data-reflex-dataset-array': '.post'
-      },
-      datasetArray: {
-        'data-controller': ['posts'],
-        'data-post-id': ['1', '2', '3'],
-        'data-post-ids': ['4'],
         'data-reflex-dataset': ['.post'],
         'data-reflex-dataset-array': ['.post']
       }

--- a/javascript/test/attributes.extractElementDataset.test.js
+++ b/javascript/test/attributes.extractElementDataset.test.js
@@ -16,7 +16,10 @@ describe('extractElementDataset', () => {
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
-    const expected = {}
+    const expected = {
+      dataset: {},
+      datasetArray: {}
+    }
     assert.deepStrictEqual(actual, expected)
   })
 
@@ -28,9 +31,12 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345'
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -47,9 +53,12 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345'
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -65,9 +74,12 @@ describe('extractElementDataset', () => {
     global.document = dom.window.document
     const element = dom.window.document.querySelector('a')
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345'
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(extractElementDataset(element), expected)
 
@@ -99,10 +111,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345',
-      'data-reflex-dataset': ''
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345',
+        'data-reflex-dataset': ''
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -119,10 +134,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345',
-      'data-reflex-dataset': 'whut'
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345',
+        'data-reflex-dataset': 'whut'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -141,13 +159,16 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345',
-      'data-grandparent-id': '456',
-      'data-parent-id': '123',
-      'data-body-id': 'body',
-      'data-reflex-dataset': 'combined'
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345',
+        'data-grandparent-id': '456',
+        'data-parent-id': '123',
+        'data-body-id': 'body',
+        'data-reflex-dataset': 'combined'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -164,8 +185,11 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-info': 'this is the inner one',
-      'data-reflex-dataset': 'combined'
+      dataset: {
+        'data-info': 'this is the inner one',
+        'data-reflex-dataset': 'combined'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -184,13 +208,19 @@ describe('extractElementDataset', () => {
     const button1 = dom.window.document.querySelector('#button1')
     const actual_button1 = extractElementDataset(button1)
     const expected_button1 = {
-      'data-parent-id': '123',
-      'data-reflex-dataset': 'combined'
+      dataset: {
+        'data-parent-id': '123',
+        'data-reflex-dataset': 'combined'
+      },
+      datasetArray: {}
     }
 
     const button2 = dom.window.document.querySelector('#button2')
     const actual_button2 = extractElementDataset(button2)
-    const expected_button2 = {}
+    const expected_button2 = {
+      dataset: {},
+      datasetArray: {}
+    }
 
     assert.deepStrictEqual(actual_button1, expected_button1)
     assert.deepStrictEqual(actual_button2, expected_button2)
@@ -212,13 +242,16 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('a')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-reflex': 'bar',
-      'data-info': '12345',
-      'data-grandparent-id': '456',
-      'data-parent-id': '123',
-      'data-body-id': 'body',
-      'data-reflex-dataset-renamed': 'combined'
+      dataset: {
+        'data-controller': 'foo',
+        'data-reflex': 'bar',
+        'data-info': '12345',
+        'data-grandparent-id': '456',
+        'data-parent-id': '123',
+        'data-body-id': 'body',
+        'data-reflex-dataset-renamed': 'combined'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -234,9 +267,12 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-age': '12',
-      'data-reflex-dataset': '#timmy'
+      dataset: {
+        'data-controller': 'foo',
+        'data-age': '12',
+        'data-reflex-dataset': '#timmy'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -255,10 +291,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-span-one': '1',
-      'data-span-two': '2',
-      'data-reflex-dataset': 'span'
+      dataset: {
+        'data-controller': 'foo',
+        'data-span-one': '1',
+        'data-span-two': '2',
+        'data-reflex-dataset': 'span'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -279,10 +318,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-span-one': '1',
-      'data-span-two': '2',
-      'data-reflex-dataset': 'span.post'
+      dataset: {
+        'data-controller': 'foo',
+        'data-span-one': '1',
+        'data-span-two': '2',
+        'data-reflex-dataset': 'span.post'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -299,10 +341,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-one': '1',
-      'data-two': '2',
-      'data-reflex-dataset': '#timmy'
+      dataset: {
+        'data-controller': 'foo',
+        'data-one': '1',
+        'data-two': '2',
+        'data-reflex-dataset': '#timmy'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -321,12 +366,15 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-one-id': '1',
-      'data-two-id': '2',
-      'data-three-id': '3',
-      'data-four-id': '4',
-      'data-reflex-dataset': '#post1 #post2 #post3 #post4'
+      dataset: {
+        'data-controller': 'foo',
+        'data-one-id': '1',
+        'data-two-id': '2',
+        'data-three-id': '3',
+        'data-four-id': '4',
+        'data-reflex-dataset': '#post1 #post2 #post3 #post4'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -342,10 +390,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-id': '1',
-      'data-job': 'clerk',
-      'data-reflex-dataset': '.sarah'
+      dataset: {
+        'data-controller': 'foo',
+        'data-id': '1',
+        'data-job': 'clerk',
+        'data-reflex-dataset': '.sarah'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -362,11 +413,14 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-id': '1',
-      'data-one-id': '1',
-      'data-two-id': '2',
-      'data-reflex-dataset': '.post'
+      dataset: {
+        'data-controller': 'foo',
+        'data-id': '1',
+        'data-one-id': '1',
+        'data-two-id': '2',
+        'data-reflex-dataset': '.post'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -385,13 +439,16 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-id': '1',
-      'data-one-id': '1',
-      'data-two-id': '2',
-      'data-three-id': '3',
-      'data-four-id': '4',
-      'data-reflex-dataset': '.post1 .post2 .post3 .post4'
+      dataset: {
+        'data-controller': 'foo',
+        'data-id': '1',
+        'data-one-id': '1',
+        'data-two-id': '2',
+        'data-three-id': '3',
+        'data-four-id': '4',
+        'data-reflex-dataset': '.post1 .post2 .post3 .post4'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -411,16 +468,20 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'posts',
-      'data-controllers': ['posts'],
-      'data-id': '1',
-      'data-ids': ['1'],
-      'data-post-id': '1',
-      'data-post-ids': ['1', '2', '3', '4'],
-      'data-reflex-dataset': '.post',
-      'data-reflex-datasets': ['.post'],
-      'data-reflex-dataset-array': '.post',
-      'data-reflex-dataset-arrays': ['.post']
+      dataset: {
+        'data-controller': 'posts',
+        'data-id': '1',
+        'data-post-id': '1',
+        'data-reflex-dataset': '.post',
+        'data-reflex-dataset-array': '.post'
+      },
+      datasetArray: {
+        'data-controller': ['posts'],
+        'data-id': ['1'],
+        'data-post-id': ['1', '2', '3', '4'],
+        'data-reflex-dataset': ['.post'],
+        'data-reflex-dataset-array': ['.post']
+      }
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -439,12 +500,16 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'posts',
-      'data-controllers': ['posts'],
-      'data-post-id': '1',
-      'data-post-ids': ['1', '2', '3', '4'],
-      'data-reflex-dataset-array': '.post',
-      'data-reflex-dataset-arrays': ['.post']
+      dataset: {
+        'data-controller': 'posts',
+        'data-post-id': '1',
+        'data-reflex-dataset-array': '.post'
+      },
+      datasetArray: {
+        'data-controller': ['posts'],
+        'data-post-id': ['1', '2', '3', '4'],
+        'data-reflex-dataset-array': ['.post']
+      }
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -463,15 +528,20 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'posts',
-      'data-controllers': ['posts'],
-      'data-post-id': '2',
-      'data-post-ids': ['1', '2', '3', '4'],
-      'data-post-idss': ['1'],
-      'data-reflex-dataset': '.post',
-      'data-reflex-datasets': ['.post'],
-      'data-reflex-dataset-array': '.post',
-      'data-reflex-dataset-arrays': ['.post']
+      dataset: {
+        'data-controller': 'posts',
+        'data-post-id': '2',
+        'data-post-ids': '1',
+        'data-reflex-dataset': '.post',
+        'data-reflex-dataset-array': '.post'
+      },
+      datasetArray: {
+        'data-controller': ['posts'],
+        'data-post-id': ['2', '3', '4'],
+        'data-post-ids': ['1'],
+        'data-reflex-dataset': ['.post'],
+        'data-reflex-dataset-array': ['.post']
+      }
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -490,15 +560,20 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'posts',
-      'data-controllers': ['posts'],
-      'data-post-id': '1',
-      'data-post-ids': ['1', '2', '3', '4'],
-      'data-post-idss': ['2', '3'],
-      'data-reflex-dataset': '.post',
-      'data-reflex-datasets': ['.post'],
-      'data-reflex-dataset-array': '.post',
-      'data-reflex-dataset-arrays': ['.post']
+      dataset: {
+        'data-controller': 'posts',
+        'data-post-id': '1',
+        'data-post-ids': '2',
+        'data-reflex-dataset': '.post',
+        'data-reflex-dataset-array': '.post'
+      },
+      datasetArray: {
+        'data-controller': ['posts'],
+        'data-post-id': ['1', '4'],
+        'data-post-ids': ['2', '3'],
+        'data-reflex-dataset': ['.post'],
+        'data-reflex-dataset-array': ['.post']
+      }
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -517,20 +592,25 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'posts',
-      'data-controllers': ['posts'],
-      'data-post-id': '1',
-      'data-post-ids': ['1', '2', '3', '4'],
-      'data-post-idss': ['4'],
-      'data-reflex-dataset': '.post',
-      'data-reflex-datasets': ['.post'],
-      'data-reflex-dataset-array': '.post',
-      'data-reflex-dataset-arrays': ['.post']
+      dataset: {
+        'data-controller': 'posts',
+        'data-post-id': '1',
+        'data-post-ids': '4',
+        'data-reflex-dataset': '.post',
+        'data-reflex-dataset-array': '.post'
+      },
+      datasetArray: {
+        'data-controller': ['posts'],
+        'data-post-id': ['1', '2', '3'],
+        'data-post-ids': ['4'],
+        'data-reflex-dataset': ['.post'],
+        'data-reflex-dataset-array': ['.post']
+      }
     }
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('should return dataset if both singular and plural exists but no data-reflex-dataset-array is passed', () => {
+  it('should return dataset if both singular and plural key exists but no data-reflex-dataset-array is passed', () => {
     const dom = new JSDOM(
       `
       <div id="element" data-controller="posts" data-post-id="1" data-reflex-dataset=".post">
@@ -544,10 +624,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'posts',
-      'data-post-id': '1',
-      'data-post-ids': '4',
-      'data-reflex-dataset': '.post'
+      dataset: {
+        'data-controller': 'posts',
+        'data-post-id': '1',
+        'data-post-ids': '4',
+        'data-reflex-dataset': '.post'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -569,10 +652,13 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-parent-id': '1',
-      'data-child-id': '2',
-      'data-reflex-dataset': 'parent'
+      dataset: {
+        'data-controller': 'foo',
+        'data-parent-id': '1',
+        'data-child-id': '2',
+        'data-reflex-dataset': 'parent'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -596,11 +682,14 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-grandparent-id': '1',
-      'data-parent-id': '2',
-      'data-child-id': '3',
-      'data-reflex-dataset': 'ancestors'
+      dataset: {
+        'data-controller': 'foo',
+        'data-grandparent-id': '1',
+        'data-parent-id': '2',
+        'data-child-id': '3',
+        'data-reflex-dataset': 'ancestors'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -625,11 +714,14 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-id': '1',
-      'data-child-one-id': '1',
-      'data-child-two-id': '2',
-      'data-reflex-dataset': 'children'
+      dataset: {
+        'data-controller': 'foo',
+        'data-id': '1',
+        'data-child-one-id': '1',
+        'data-child-two-id': '2',
+        'data-reflex-dataset': 'children'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })
@@ -654,11 +746,14 @@ describe('extractElementDataset', () => {
     const element = dom.window.document.querySelector('#element')
     const actual = extractElementDataset(element)
     const expected = {
-      'data-controller': 'foo',
-      'data-id': '1',
-      'data-sibling-one-id': '1',
-      'data-sibling-two-id': '2',
-      'data-reflex-dataset': 'siblings'
+      dataset: {
+        'data-controller': 'foo',
+        'data-id': '1',
+        'data-sibling-one-id': '1',
+        'data-sibling-two-id': '2',
+        'data-reflex-dataset': 'siblings'
+      },
+      datasetArray: {}
     }
     assert.deepStrictEqual(actual, expected)
   })

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Element < OpenStruct
-  attr_reader :attributes, :data_attributes
+  attr_reader :attrs, :data_attrs
 
   def initialize(data = {})
-    @attributes = HashWithIndifferentAccess.new(data["attrs"] || {})
-    @data_attributes = HashWithIndifferentAccess.new(data["dataset"] || {})
-    all_attributes = @attributes.merge(@data_attributes)
+    @attrs = HashWithIndifferentAccess.new(data["attrs"] || {})
+    datasets = data["dataset"] || {}
+    regualar_dataset = datasets["dataset"] || {}
+    @data_attrs = build_data_attrs(regualar_dataset, datasets["datasetArray"] || {})
+    all_attributes = @attrs.merge(@data_attrs)
     super all_attributes.merge(all_attributes.transform_keys(&:underscore))
-    @data_attributes.transform_keys! { |key| key.delete_prefix "data-" }
+    @data_attrs.transform_keys! { |key| key.delete_prefix "data-" }
   end
 
   def signed
@@ -19,7 +21,25 @@ class StimulusReflex::Element < OpenStruct
     @unsigned ||= ->(accessor) { GlobalID::Locator.locate(dataset[accessor]) }
   end
 
+  def attributes
+    @attributes ||= OpenStruct.new(attrs.merge(attrs.transform_keys(&:underscore)))
+  end
+
+  alias_method :data_attributes, :dataset
+
   def dataset
-    @dataset ||= OpenStruct.new(data_attributes.merge(data_attributes.transform_keys(&:underscore)))
+    @dataset ||= OpenStruct.new(data_attrs.merge(data_attrs.transform_keys(&:underscore)))
+  end
+
+  private
+
+  def build_data_attrs(dataset, dataset_array)
+    dataset_array.transform_keys! { |key| "data-#{key.delete_prefix("data-").pluralize}" }
+
+    dataset.each { |key, value| dataset_array[key]&.prepend(value) }
+
+    data_attrs = dataset.merge(dataset_array)
+
+    HashWithIndifferentAccess.new(data_attrs || {})
   end
 end

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -25,11 +25,11 @@ class StimulusReflex::Element < OpenStruct
     @attributes ||= OpenStruct.new(attrs.merge(attrs.transform_keys(&:underscore)))
   end
 
-  alias_method :data_attributes, :dataset
-
   def dataset
     @dataset ||= OpenStruct.new(data_attrs.merge(data_attrs.transform_keys(&:underscore)))
   end
+
+  alias_method :data_attributes, :dataset
 
   private
 

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -9,7 +9,7 @@ class StimulusReflex::Element < OpenStruct
     regualar_dataset = datasets["dataset"] || {}
     @data_attrs = build_data_attrs(regualar_dataset, datasets["datasetArray"] || {})
     all_attributes = @attrs.merge(@data_attrs)
-    super all_attributes.merge(all_attributes.transform_keys(&:underscore))
+    super build_underscored(all_attributes)
     @data_attrs.transform_keys! { |key| key.delete_prefix "data-" }
   end
 
@@ -22,11 +22,11 @@ class StimulusReflex::Element < OpenStruct
   end
 
   def attributes
-    @attributes ||= OpenStruct.new(attrs.merge(attrs.transform_keys(&:underscore)))
+    @attributes ||= OpenStruct.new(build_underscored(attrs))
   end
 
   def dataset
-    @dataset ||= OpenStruct.new(data_attrs.merge(data_attrs.transform_keys(&:underscore)))
+    @dataset ||= OpenStruct.new(build_underscored(data_attrs))
   end
 
   alias_method :data_attributes, :dataset
@@ -41,5 +41,9 @@ class StimulusReflex::Element < OpenStruct
     data_attrs = dataset.merge(dataset_array)
 
     HashWithIndifferentAccess.new(data_attrs || {})
+  end
+
+  def build_underscored(attrs)
+    attrs.merge(attrs.transform_keys(&:underscore))
   end
 end

--- a/test/element_test.rb
+++ b/test/element_test.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class StimulusReflex::ElementTest < ActiveSupport::TestCase
+  element = StimulusReflex::Element.new({
+    "attrs" => {
+      "user" => "First User",
+      "user-id" => "1"
+    },
+    "dataset" => {
+      "dataset" => {
+        "data-post" => "The Post",
+        "data-post-id" => "2"
+      },
+      "datasetArray" => {}
+    }
+  })
+
+  test "should be able to access attributes on element itself" do
+    assert_equal "First User", element.user
+    assert_equal "First User", element["user"]
+    assert_equal "First User", element[:user]
+
+    assert_equal "1", element.user_id
+    assert_equal "1", element["user_id"]
+    assert_equal "1", element["user-id"]
+    assert_equal "1", element[:user_id]
+
+    assert_equal "The Post", element.data_post
+    assert_equal "The Post", element["data_post"]
+    assert_equal "The Post", element["data-post"]
+    assert_equal "The Post", element[:data_post]
+
+    assert_equal "2", element.data_post_id
+    assert_equal "2", element["data_post_id"]
+    assert_equal "2", element["data-post-id"]
+    assert_equal "2", element[:data_post_id]
+  end
+
+  test "should be able to access attributes via attributes" do
+    assert_equal "First User", element.attributes.user
+    assert_equal "First User", element.attributes["user"]
+    assert_equal "First User", element.attributes[:user]
+
+    assert_equal "1", element.attributes.user_id
+    assert_equal "1", element.attributes["user_id"]
+    assert_equal "1", element.attributes["user-id"]
+    assert_equal "1", element.attributes[:user_id]
+  end
+
+  test "should be able to access attributes via dataset" do
+    assert_equal "The Post", element.dataset.post
+    assert_equal "The Post", element.dataset["post"]
+    assert_equal "The Post", element.dataset[:post]
+
+    assert_equal "2", element.dataset.post_id
+    assert_equal "2", element.dataset["post-id"]
+    assert_equal "2", element.dataset["post_id"]
+    assert_equal "2", element.dataset[:post_id]
+  end
+
+  test "should be able to access attributes via data_attributes" do
+    assert_equal "The Post", element.data_attributes.post
+    assert_equal "The Post", element.data_attributes["post"]
+    assert_equal "The Post", element.data_attributes[:post]
+
+    assert_equal "2", element.data_attributes.post_id
+    assert_equal "2", element.data_attributes["post-id"]
+    assert_equal "2", element.data_attributes["post_id"]
+    assert_equal "2", element.data_attributes[:post_id]
+  end
+
+  test "should pluralize keys from datasetArray" do
+    data = {
+      "dataset" => {
+        "dataset" => {
+          "data-reflex" => "click",
+          "data-sex" => "male"
+        },
+        "datasetArray" => {
+          "data-reflex" => ["click"],
+          "data-post-id" => ["1", "2", "3", "4"],
+          "data-name" => ["steve", "bill", "steve", "mike"]
+        }
+      }
+    }
+
+    dataset_array_element = StimulusReflex::Element.new(data)
+
+    assert_equal "click", dataset_array_element.dataset.reflex
+    assert_equal "male", dataset_array_element.dataset.sex
+
+    assert_equal ["steve", "bill", "steve", "mike"], dataset_array_element.dataset.names
+    assert_equal ["1", "2", "3", "4"], dataset_array_element.dataset.post_ids
+    assert_equal ["click"], dataset_array_element.dataset.reflexes
+  end
+
+  test "should pluralize irregular words from datasetArray" do
+    data = {
+      "dataset" => {
+        "dataset" => {},
+        "datasetArray" => {
+          "data-cat" => ["cat"],
+          "data-child" => ["child"],
+          "data-women" => ["woman"],
+          "data-man" => ["man"],
+          "data-wolf" => ["wolf"],
+          "data-library" => ["library"],
+          "data-mouse" => ["mouse"]
+        }
+      }
+    }
+
+    pluralize_element = StimulusReflex::Element.new(data)
+
+    assert_equal ["cat"], pluralize_element.dataset.cats
+    assert_equal ["child"], pluralize_element.dataset.children
+    assert_equal ["woman"], pluralize_element.dataset.women
+    assert_equal ["man"], pluralize_element.dataset.men
+    assert_equal ["wolf"], pluralize_element.dataset.wolves
+    assert_equal ["library"], pluralize_element.dataset.libraries
+    assert_equal ["mouse"], pluralize_element.dataset.mice
+  end
+
+  test "should not pluralize plural key" do
+    data = {
+      "dataset" => {
+        "datasetArray" => {
+          "data-ids" => ["1", "2"]
+        }
+      }
+    }
+
+    assert_equal ["1", "2"], StimulusReflex::Element.new(data).dataset.ids
+    assert_nil StimulusReflex::Element.new(data).dataset.idss
+  end
+
+  test "should not build array with pluralized key" do
+    data = {
+      "dataset" => {
+        "dataset" => {
+          "data-ids" => "1"
+        }
+      }
+    }
+
+    assert_equal "1", StimulusReflex::Element.new(data).dataset.ids
+  end
+
+  test "should handle overlapping singluar and plural key names" do
+    data = {
+      "dataset" => {
+        "dataset" => {
+          "data-id" => "1",
+          "data-ids" => "2",
+          "data-post-id" => "9",
+          "data-post-ids" => "10",
+          "data-duplicate-value" => "19",
+          "data-duplicate-values" => "20"
+        },
+        "datasetArray" => {
+          "data-id" => ["3", "4"],
+          "data-post-ids" => ["11", "12"],
+          "data-duplicate-value" => ["20", "21", "22"]
+        }
+      }
+    }
+
+    overlapping_keys_element = StimulusReflex::Element.new(data)
+
+    assert_equal "1", overlapping_keys_element.dataset.id
+    assert_equal ["2", "3", "4"], overlapping_keys_element.dataset.ids
+
+    assert_equal "9", overlapping_keys_element.dataset.post_id
+    assert_equal ["10", "11", "12"], overlapping_keys_element.dataset.post_ids
+
+    assert_equal "19", overlapping_keys_element.dataset.duplicate_value
+    assert_equal ["20", "20", "21", "22"], overlapping_keys_element.dataset.duplicate_values
+  end
+end


### PR DESCRIPTION
This PR splits up the dataset payload to `dataset` and `datasetArray` so the server is able to apply the pluralization to the dataset keys.  

I've also added some tests to cover the `StimulusReflex::Element` class